### PR TITLE
wrong mismatch strings fix

### DIFF
--- a/basics/string-manipulation.mdx
+++ b/basics/string-manipulation.mdx
@@ -100,7 +100,7 @@ print(new_message)  # "I love JavaScript programming with JavaScript"
   <Accordion title="Wrong quotes in strings">
     ```python
     # Wrong - mismatched quotes
-    text = "It's Python"
+    text = 'It's Python'
     
     # Right - escape or use different quotes
     text = "It's Python"  # Double quotes outside


### PR DESCRIPTION
this is not wrong 
Wrong - mismatched quotes
text = "It's Python"

the wrong version should be
text = 'It's Python'